### PR TITLE
Add SEO assets and badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Repository of Entries - Marco Vinicio
 
-[![Build Status](https://img.shields.io/badge/status-in%20development-yellow.svg)](https://github.com/MarcoS9309/Repositorio-de-entradas)
-[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![CI](https://github.com/MarcoS9309/Repositorio-de-entradas/actions/workflows/jekyll-docker.yml/badge.svg)](https://github.com/MarcoS9309/Repositorio-de-entradas/actions/workflows/jekyll-docker.yml)
+[![Coverage](https://img.shields.io/badge/coverage-0%25-red.svg)](https://github.com/MarcoS9309/Repositorio-de-entradas)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![GitHub Pages](https://img.shields.io/badge/GitHub%20Pages-active-brightgreen.svg)](https://marcos9309.github.io/Repositorio-de-entradas/)
 
 ## Project Description

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,8 @@
+# Release Notes
+
+## v1.0.0 - Initial public release
+
+- Public repository with creative content and projects.
+- Added basic GitHub Actions workflow to build the site.
+- Included MIT License.
+- Provides various sections like Daily logs, Reflections and JavaScript exercises.

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://marcos9309.github.io/Repositorio-de-entradas/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://marcos9309.github.io/Repositorio-de-entradas/</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- add CI, coverage, license and GitHub Pages badges to README
- include sitemap.xml and robots.txt for SEO
- document first release

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_68892f21f9408332aaa1677e9cdb67f9